### PR TITLE
traits 003: overwrite KV bug, inline memcpy, userspace tests

### DIFF
--- a/include/net/trait.h
+++ b/include/net/trait.h
@@ -1,0 +1,83 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __LINUX_NET_TRAIT_H__
+#define __LINUX_NET_TRAIT_H__
+
+#include <linux/types.h>
+#include <linux/errno.h>
+#include <linux/string.h>
+
+#define __TRAITS_HDR_SIZE (16)
+
+/**
+ * traits_init() - Initialize a trait store.
+ * @traits: Start of trait store area.
+ * @hard_end: Hard limit the trait store can currently grow up against.
+ *            Can change dynamically after initialization, as long as it
+ *            does not overwrite any area already used (see traits_size()).
+ *
+ * Return:
+ * * %0       - Success.
+ * * %-ENOMEM - Not enough room to store any traits.
+ */
+static __always_inline int traits_init(void *traits, void *hard_end)
+{
+	if (traits + __TRAITS_HDR_SIZE > hard_end)
+		return -ENOMEM;
+
+	memset(traits, 0, __TRAITS_HDR_SIZE);
+	return 0;
+}
+
+/**
+ * traits_size() - Total size currently used by a trait store.
+ * @traits: Start of trait store area.
+ *
+ * Return: Size in bytes.
+ */
+int traits_size(void *traits);
+
+/**
+ * trait_set() - Set a trait key.
+ * @traits: Start of trait store area.
+ * @hard_end: Hard limit the trait store can currently grow up against.
+ * @key: The key to set.
+ * @val: The value to set.
+ * @len: The length of the value.
+ * @flags: Unused for now. Should be 0.
+ *
+ * Return:
+ * * %0       - Success.
+ * * %-EINVAL - Key or length invalid.
+ * * %-ENOMEM - Not enough room left to store value.
+ */
+int trait_set(void *traits, void *hard_end, u64 key, const void *val, u64 len,
+	      u64 flags);
+
+/**
+ * trait_get() - Get a trait key.
+ * @traits: Start of trait store area.
+ * @key: The key to get.
+ * @val: Where to put stored value.
+ * @val_len: The length of val.
+ *
+ * Return:
+ * * %0       - Success.
+ * * %-EINVAL - Key or length invalid.
+ * * %-ENOENT - Key has not been set with trait_set() previously.
+ * * %-EFBIG  - Val is not big enough to hold stored value.
+ */
+int trait_get(void *traits, u64 key, void *val, u64 val_len);
+
+/**
+ * trait_del() - Delete a trait key.
+ * @traits: Start of trait store area.
+ * @key: The key to delete.
+ *
+ * Return:
+ * * %0       - Success.
+ * * %-EINVAL - Key or length invalid.
+ * * %-ENOENT - Key has not been set with trait_set() previously.
+ */
+int trait_del(void *traits, u64 key);
+
+#endif /* __LINUX_NET_TRAIT_H__ */

--- a/include/net/xdp.h
+++ b/include/net/xdp.h
@@ -10,6 +10,7 @@
 #include <linux/filter.h>
 #include <linux/netdevice.h>
 #include <linux/skbuff.h> /* skb_shared_info */
+#include <net/trait.h>
 
 /**
  * DOC: XDP RX-queue information
@@ -113,6 +114,27 @@ static __always_inline void xdp_buff_set_frag_pfmemalloc(struct xdp_buff *xdp)
 	xdp->flags |= XDP_FLAGS_FRAGS_PF_MEMALLOC;
 }
 
+// TODO - just moving this is horrible.
+// Maybe we should move all the helpers too?
+struct xdp_frame {
+	void *data;
+	u16 len;
+	u16 headroom;
+	u32 metasize; /* uses lower 8-bits */
+	/* Lifetime of xdp_rxq_info is limited to NAPI/enqueue time,
+	 * while mem info is valid on remote CPU.
+	 */
+	struct xdp_mem_info mem;
+	struct net_device *dev_rx; /* used by cpumap */
+	u32 frame_sz;
+	u32 flags; /* supported values defined in xdp_buff_flags */
+};
+
+static __always_inline void *xdp_traits(const struct xdp_buff *xdp)
+{
+	return xdp->data_hard_start + sizeof(struct xdp_frame);
+}
+
 static __always_inline void
 xdp_init_buff(struct xdp_buff *xdp, u32 frame_sz, struct xdp_rxq_info *rxq)
 {
@@ -131,6 +153,13 @@ xdp_prepare_buff(struct xdp_buff *xdp, unsigned char *hard_start,
 	xdp->data = data;
 	xdp->data_end = data + data_len;
 	xdp->data_meta = meta_valid ? data : data + 1;
+
+	if (meta_valid) {
+		/* We assume drivers reserve enough headroom to store xdp_frame
+		 * and the traits header.
+		 */
+		traits_init(xdp_traits(xdp), xdp->data_meta);
+	}
 }
 
 /* Reserve memory area at end-of data area.
@@ -162,20 +191,6 @@ static __always_inline unsigned int xdp_get_buff_len(struct xdp_buff *xdp)
 out:
 	return len;
 }
-
-struct xdp_frame {
-	void *data;
-	u16 len;
-	u16 headroom;
-	u32 metasize; /* uses lower 8-bits */
-	/* Lifetime of xdp_rxq_info is limited to NAPI/enqueue time,
-	 * while mem info is valid on remote CPU.
-	 */
-	struct xdp_mem_info mem;
-	struct net_device *dev_rx; /* used by cpumap */
-	u32 frame_sz;
-	u32 flags; /* supported values defined in xdp_buff_flags */
-};
 
 static __always_inline bool xdp_frame_has_frags(struct xdp_frame *frame)
 {
@@ -375,6 +390,11 @@ static inline bool xdp_metalen_invalid(unsigned long metalen)
 	BUILD_BUG_ON(!__builtin_constant_p(meta_max));
 
 	return !IS_ALIGNED(metalen, sizeof(u32)) || metalen > meta_max;
+}
+
+static __always_inline void *xdp_meta_hard_start(const struct xdp_buff *xdp)
+{
+	return xdp_traits(xdp) + traits_size(xdp_traits(xdp));
 }
 
 struct xdp_attachment_info {

--- a/net/core/Makefile
+++ b/net/core/Makefile
@@ -5,7 +5,7 @@
 
 obj-y := sock.o request_sock.o skbuff.o datagram.o stream.o scm.o \
 	 gen_stats.o gen_estimator.o net_namespace.o secure_seq.o \
-	 flow_dissector.o
+	 flow_dissector.o trait.o
 
 obj-$(CONFIG_SYSCTL) += sysctl_net_core.o
 

--- a/net/core/trait.c
+++ b/net/core/trait.c
@@ -3,6 +3,7 @@
 #include <linux/errno.h>
 #include <linux/string.h>
 #include <linux/bitops.h>
+#include <linux/unaligned.h>
 #include <net/trait.h>
 
 /* Very limited KV support:
@@ -92,23 +93,23 @@ int trait_set(void *traits, void *hard_end, u64 key, const void *val, u64 len,
 			memmove(traits + off + len, traits + off, traits_size(traits) - off);
 	}
 
-	/* Set our value. */
-	memcpy(traits + off, val, len);
-
-	/* Store our length in header. */
 	u64 encode_len = 0;
-
 	switch (len) {
 	case 2:
+		/* Values are least two bytes, so they'll be two byte aligned */
+		*(u16 *)(traits + off) = *(u16 *)val;
 		encode_len = 1;
 		break;
 	case 4:
+		put_unaligned(*(u32 *)val, (u32 *)(traits + off));
 		encode_len = 2;
 		break;
 	case 8:
+		put_unaligned(*(u64 *)val, (u64 *)(traits + off));
 		encode_len = 3;
 		break;
 	}
+
 	h->high |= (encode_len >> 1) << key;
 	h->low |= (encode_len & 1) << key;
 	return 0;
@@ -134,7 +135,19 @@ int trait_get(void *traits, u64 key, void *val, u64 val_len)
 	if (real_len > val_len)
 		return -EFBIG;
 
-	memcpy(val, traits + off, real_len);
+	switch (real_len) {
+	case 2:
+		/* Values are least two bytes, so they'll be two byte aligned */
+		*(u16 *)val = *(u16 *)(traits + off);
+		break;
+	case 4:
+		*(u32 *)val = get_unaligned((u32 *)(traits + off));
+		break;
+	case 8:
+		*(u64 *)val = get_unaligned((u64 *)(traits + off));
+		break;
+	}
+
 	return real_len;
 }
 

--- a/net/core/trait.c
+++ b/net/core/trait.c
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/types.h>
+#include <linux/errno.h>
+#include <linux/string.h>
+#include <linux/bitops.h>
+#include <net/trait.h>
+
+/* Very limited KV support:
+ *
+ * - Keys: 0-63. (TBD which are reserved for the kernel)
+ * - Value size: 2, 4, or 8.
+ *
+ * But compact, uses a fixed 16 byte header only.
+ * Reasonably fast access.
+ * Insertion and deletion need a memmove (entries have to be sorted),
+ * but it's ~100s of bytes of max.
+ *
+ * TODO - should we support more sizes? Can switch to three bits per entry.
+ * TODO - should we support a 0 size to just the presence / absence of key without a value?
+ */
+static bool valid_len(u64 len)
+{
+	return len == 2 || len == 4 || len == 8;
+}
+
+static bool valid_key(u64 key)
+{
+	return key < 64;
+}
+
+/* Fixed header at the start of our area */
+struct hdr {
+	/* 2 bit length is stored for each key:
+	 *  a high bit in the high word.
+	 *  a low bit in the low word.
+	 * Key itself is the bit position in each word, LSb 0.
+	 * This lets us count the bits in high and low to easily
+	 * calculate the sum of the preceding KVs lengths.
+	 */
+	u64 high;
+	u64 low;
+};
+
+static_assert(sizeof(struct hdr) == __TRAITS_HDR_SIZE);
+
+static int total_length(struct hdr h)
+{
+	return (hweight64(h.high) << 2) + (hweight64(h.low) << 1);
+}
+
+static struct hdr and(struct hdr h, u64 mask)
+{
+	return (struct hdr){
+		h.high & mask,
+		h.low & mask,
+	};
+}
+
+static int offset(struct hdr h, u64 key)
+{
+	/* Calculate total length of previous keys by masking out keys after. */
+	return sizeof(struct hdr) + total_length(and(h, ~(~0llu << key)));
+}
+
+int traits_size(void *traits)
+{
+	return sizeof(struct hdr) + total_length(*(struct hdr *)traits);
+}
+
+int trait_set(void *traits, void *hard_end, u64 key, const void *val, u64 len,
+	      u64 flags)
+{
+	if (!valid_key(key) || !valid_len(len))
+		return -EINVAL;
+
+	struct hdr *h = (struct hdr *)traits;
+
+	/* Offset of value of this key. */
+	int off = offset(*h, key);
+
+	if ((h->high & (1ull << key)) || (h->low & (1ull << key))) {
+		/* Key is already set, but with a different length */
+		if (total_length(and(*h, (1ull << key))) != len)
+			return -EINVAL;
+	} else {
+		/* Figure out if we have enough room left: total length of everything now. */
+		if (traits + sizeof(struct hdr) + total_length(*h) + len > hard_end)
+			return -ENOMEM;
+
+		/* Memmove all the kvs after us over. */
+		if (traits_size(traits) > off)
+			memmove(traits + off + len, traits + off, traits_size(traits) - off);
+	}
+
+	/* Set our value. */
+	memcpy(traits + off, val, len);
+
+	/* Store our length in header. */
+	u64 encode_len = 0;
+
+	switch (len) {
+	case 2:
+		encode_len = 1;
+		break;
+	case 4:
+		encode_len = 2;
+		break;
+	case 8:
+		encode_len = 3;
+		break;
+	}
+	h->high |= (encode_len >> 1) << key;
+	h->low |= (encode_len & 1) << key;
+	return 0;
+}
+
+int trait_get(void *traits, u64 key, void *val, u64 val_len)
+{
+	if (!valid_key(key))
+		return -EINVAL;
+
+	struct hdr h = *(struct hdr *)traits;
+
+	/* Check key is set */
+	if (!((h.high & (1ull << key)) || (h.low & (1ull << key))))
+		return -ENOENT;
+
+	/* Offset of value of this key */
+	int off = offset(h, key);
+
+	/* Figure out our length */
+	int real_len = total_length(and(h, (1ull << key)));
+
+	if (real_len > val_len)
+		return -EFBIG;
+
+	memcpy(val, traits + off, real_len);
+	return real_len;
+}
+
+int trait_del(void *traits, u64 key)
+{
+	if (!valid_key(key))
+		return -EINVAL;
+
+	struct hdr *h = (struct hdr *)traits;
+
+	/* Check key is set */
+	if (!((h->high & (1ull << key)) || (h->low & (1ull << key))))
+		return -ENOENT;
+
+	/* Offset and length of value of this key */
+	int off = offset(*h, key);
+	int len = total_length(and(*h, (1ull << key)));
+
+	/* Memmove all the kvs after us over */
+	if (traits_size(traits) > off + len)
+		memmove(traits + off, traits + off + len, traits_size(traits) - off - len);
+
+	/* Clear our length in header */
+	h->high &= ~(1ull << key);
+	h->low &= ~(1ull << key);
+	return 0;
+}

--- a/net/core/trait.c
+++ b/net/core/trait.c
@@ -18,12 +18,12 @@
  * TODO - should we support more sizes? Can switch to three bits per entry.
  * TODO - should we support a 0 size to just the presence / absence of key without a value?
  */
-static bool valid_len(u64 len)
+static __always_inline bool valid_len(u64 len)
 {
 	return len == 2 || len == 4 || len == 8;
 }
 
-static bool valid_key(u64 key)
+static __always_inline bool valid_key(u64 key)
 {
 	return key < 64;
 }
@@ -43,12 +43,12 @@ struct hdr {
 
 static_assert(sizeof(struct hdr) == __TRAITS_HDR_SIZE);
 
-static int total_length(struct hdr h)
+static __always_inline int total_length(struct hdr h)
 {
 	return (hweight64(h.high) << 2) + (hweight64(h.low) << 1);
 }
 
-static struct hdr and(struct hdr h, u64 mask)
+static __always_inline struct hdr and(struct hdr h, u64 mask)
 {
 	return (struct hdr){
 		h.high & mask,
@@ -56,7 +56,7 @@ static struct hdr and(struct hdr h, u64 mask)
 	};
 }
 
-static int offset(struct hdr h, u64 key)
+static __always_inline int offset(struct hdr h, u64 key)
 {
 	/* Calculate total length of previous keys by masking out keys after. */
 	return sizeof(struct hdr) + total_length(and(h, ~(~0llu << key)));

--- a/net/core/xdp.c
+++ b/net/core/xdp.c
@@ -832,3 +832,53 @@ void xdp_features_clear_redirect_target(struct net_device *dev)
 	xdp_set_features_flag(dev, val);
 }
 EXPORT_SYMBOL_GPL(xdp_features_clear_redirect_target);
+
+__bpf_kfunc_start_defs();
+
+__bpf_kfunc int bpf_xdp_trait_set(const struct xdp_buff *xdp, u64 key,
+				  const void *val, u64 val__sz, u64 flags)
+{
+	if (xdp_data_meta_unsupported(xdp))
+		return -EOPNOTSUPP;
+
+	return trait_set(xdp_traits(xdp), xdp->data_meta, key,
+			 val, val__sz, flags);
+}
+
+__bpf_kfunc int bpf_xdp_trait_get(const struct xdp_buff *xdp, u64 key,
+				  void *val, u64 val__sz)
+{
+	if (xdp_data_meta_unsupported(xdp))
+		return -EOPNOTSUPP;
+
+	return trait_get(xdp_traits(xdp), key, val, val__sz);
+}
+
+__bpf_kfunc int bpf_xdp_trait_del(const struct xdp_buff *xdp, u64 key)
+{
+	if (xdp_data_meta_unsupported(xdp))
+		return -EOPNOTSUPP;
+
+	return trait_del(xdp_traits(xdp), key);
+}
+
+__bpf_kfunc_end_defs();
+
+BTF_KFUNCS_START(xdp_trait)
+// TODO - should we use KF_TRUSTED_ARGS? https://www.kernel.org/doc/html/next/bpf/kfuncs.html#kf-trusted-args-flag
+BTF_ID_FLAGS(func, bpf_xdp_trait_set)
+BTF_ID_FLAGS(func, bpf_xdp_trait_get)
+BTF_ID_FLAGS(func, bpf_xdp_trait_del)
+BTF_KFUNCS_END(xdp_trait)
+
+static const struct btf_kfunc_id_set xdp_trait_kfunc_set = {
+	.owner = THIS_MODULE,
+	.set = &xdp_trait,
+};
+
+static int xdp_trait_init(void)
+{
+	return register_btf_kfunc_id_set(BPF_PROG_TYPE_XDP,
+					 &xdp_trait_kfunc_set);
+}
+late_initcall(xdp_trait_init);

--- a/tools/testing/selftests/bpf/prog_tests/xdp_traits.c
+++ b/tools/testing/selftests/bpf/prog_tests/xdp_traits.c
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <test_progs.h>
+#include <network_helpers.h>
+
+static void _test_xdp_traits(void)
+{
+	const char *file = "./test_xdp_traits.bpf.o";
+	struct bpf_object *obj;
+	int err, prog_fd;
+	char buf[128];
+
+	LIBBPF_OPTS(bpf_test_run_opts, topts,
+		.data_in = &pkt_v4,
+		.data_size_in = sizeof(pkt_v4),
+		.data_out = buf,
+		.data_size_out = sizeof(buf),
+		.repeat = 1,
+	);
+
+	err = bpf_prog_test_load(file, BPF_PROG_TYPE_XDP, &obj, &prog_fd);
+	if (!ASSERT_OK(err, "test_xdp_traits"))
+		return;
+
+	err = bpf_prog_test_run_opts(prog_fd, &topts);
+	ASSERT_OK(err, "prog_run");
+	ASSERT_EQ(topts.retval, XDP_PASS, "retval");
+
+	bpf_object__close(obj);
+}
+
+void test_xdp_traits(void)
+{
+	if (test__start_subtest("xdp_traits"))
+		_test_xdp_traits();
+}

--- a/tools/testing/selftests/bpf/progs/test_xdp_traits.c
+++ b/tools/testing/selftests/bpf/progs/test_xdp_traits.c
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include <errno.h>
+
+extern int bpf_xdp_trait_set(const struct xdp_md *xdp, __u64 key,
+			     const void *val, __u64 val__sz,
+			     __u64 flags) __ksym;
+extern int bpf_xdp_trait_get(const struct xdp_md *xdp, __u64 key, void *val,
+			     __u64 val__sz) __ksym;
+extern int bpf_xdp_trait_del(const struct xdp_md *xdp, __u64 key) __ksym;
+
+SEC("xdp")
+int _xdp_traits(struct xdp_md *xdp)
+{
+	int ret;
+	__u16 val, got, want;
+
+	// No keys to start.
+	for (int i = 0; i < 64; i++) {
+		ret = bpf_xdp_trait_get(xdp, i, &val, sizeof(val));
+		if (ret != -ENOENT) {
+			bpf_printk("get(%d) ret %d", i, ret);
+			return XDP_DROP;
+		}
+	}
+
+	// Set 64 2 byte KVs.
+	for (int i = 0; i < 64; i++) {
+		val = i << 8 | i;
+		ret = bpf_xdp_trait_set(xdp, i, &val, sizeof(val), 0);
+		if (ret < 0) {
+			bpf_printk("set(%d) ret %d\n", i, ret);
+			return XDP_DROP;
+		}
+		bpf_printk("set(%d, 0x%04x)\n", i, val);
+	}
+
+	// Check we can get the 64 2 byte KVs back out.
+	for (int i = 0; i < 64; i++) {
+		ret = bpf_xdp_trait_get(xdp, i, &got, sizeof(got));
+		if (ret != 2) {
+			bpf_printk("get(%d) ret %d", i, ret);
+			return XDP_DROP;
+		}
+		want = (i << 8) | i;
+		if (got != want) {
+			bpf_printk("get(%d) got 0x%04x want 0x%04x\n", i, got,
+				   want);
+			return XDP_DROP;
+		}
+		bpf_printk("get(%d) 0x%04x\n", i, got);
+	}
+
+	// Overwrite all 64 2 byte KVs.
+	for (int i = 0; i < 64; i++) {
+		val = i << 9 | i << 1;
+		ret = bpf_xdp_trait_set(xdp, i, &val, sizeof(val), 0);
+		if (ret < 0) {
+			bpf_printk("set(%d) ret %d\n", i, ret);
+			return XDP_DROP;
+		}
+		bpf_printk("set(%d, 0x%04x)\n", i, val);
+	}
+
+	// Delete all the even KVs.
+	for (int i = 0; i < 64; i += 2) {
+		ret = bpf_xdp_trait_del(xdp, i);
+		if (ret < 0) {
+			bpf_printk("del(%d) ret %d\n", i, ret);
+			return XDP_DROP;
+		}
+	}
+
+	// Read out all the odd KVs again.
+	for (int i = 1; i < 63; i += 2) {
+		ret = bpf_xdp_trait_get(xdp, i, &got, sizeof(got));
+		if (ret != 2) {
+			bpf_printk("get(%d) ret %d", i, ret);
+			return XDP_DROP;
+		}
+		want = (i << 9) | i << 1;
+		if (got != want) {
+			bpf_printk("get(%d) got 0x%04x want 0x%04x\n", i, got,
+				   want);
+			return XDP_DROP;
+		}
+		bpf_printk("get(%d) 0x%04x\n", i, got);
+	}
+
+	// TODO
+
+	// We can provide a bigger buffer than necessary to read a value,
+	// that isn't of a support size.
+
+	// Set(invalid_len)
+	// Set(invalid_key)
+	// Set(no more room left)
+
+	// Get(invalid_key)
+	// Get(buff too small)
+
+	// Del(invalid_key)
+	// Del(key doesn't exist)
+
+	return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/userspace-traits/Makefile
+++ b/userspace-traits/Makefile
@@ -1,0 +1,30 @@
+# Disable built in rules so we don't try to build kernel objects.
+.SUFFIXES:
+MAKEFLAGS+=-r
+
+CC:=clang-19
+
+INCLUDE_DIRS:=include/ arch/x86/include/generated/ arch/x86/include/
+DEFINES:=__KERNEL__ CONFIG_64BIT CONFIG_X86_64
+
+CC_FLAGS:=$(foreach i,$(INCLUDE_DIRS),-isystem ../$i) $(foreach d,$(DEFINES),-D $d)
+DEP_FLAGS=-MD -MP -MF $@.d
+
+# Add .user to our files so our rules aren't used for kernel objects.
+OBJS:=$(addsuffix .user.o,$(wildcard *.c *.S))
+KERNEL_OBJS:=$(addprefix ../,net/core/trait.o arch/x86/lib/hweight.o)
+
+test: $(OBJS) $(KERNEL_OBJS)
+	$(CC) -no-pie $^ -o $@
+
+clean:
+	rm $(OBJS)
+
+# Include header dependency info.
+-include $(addsuffix .d,$(OBJS))
+
+%.c.user.o: %.c
+	$(CC) $(CC_FLAGS) $(DEP_FLAGS) -c $< -o $@
+
+%.S.user.o: %.S
+	$(CC) $(CC_FLAGS) $(DEP_FLAGS) -c $< -o $@

--- a/userspace-traits/test.c
+++ b/userspace-traits/test.c
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <stdio.h>
+#include <net/trait.h>
+
+#define TRAIT_LEN (256)
+uint8_t traits[TRAIT_LEN];
+
+int main(void)
+{
+	int ret;
+	uint16_t val, got, want;
+
+	ret = traits_init(traits, traits + TRAIT_LEN);
+	if (ret != 0) {
+		printf("init() ret %d\n", ret);
+		return -1;
+	}
+
+	// No keys set to start.
+	for (int i = 0; i < 64; i++) {
+		ret = trait_get(traits, i, &got, sizeof(got));
+		if (ret != -ENOENT) {
+			printf("get(%d) want -ENOENT, ret %d\n", i, ret);
+			return -1;
+		}
+	}
+
+	// Set 64 2 byte KVs.
+	for (int i = 0; i < 64; i++) {
+		val = i << 8 | i;
+		ret = trait_set(traits, traits + TRAIT_LEN, i, &val,
+				sizeof(val), 0);
+		if (ret < 0) {
+			printf("set(%d) ret %d\n", i, ret);
+			return -1;
+		}
+		printf("set(%d, 0x%04x)\n", i, val);
+	}
+
+	// Check we can get the 64 2 byte KVs back out.
+	for (int i = 0; i < 64; i++) {
+		ret = trait_get(traits, i, &got, sizeof(got));
+		if (ret < 0) {
+			printf("get(%d) ret %d\n", i, ret);
+			return -1;
+		}
+		want = (i << 8) | i;
+		if (got != want) {
+			printf("get(%d) got 0x%04x want 0x%04x\n", i, got,
+			       want);
+			return -1;
+		}
+		printf("get(%d) 0x%04x\n", i, got);
+	}
+
+	// Overwrite all 64 2 byte KVs.
+	for (int i = 0; i < 64; i++) {
+		val = i << 9 | i << 1;
+		ret = trait_set(traits, traits + TRAIT_LEN, i, &val,
+				sizeof(val), 0);
+		if (ret < 0) {
+			printf("set(%d) ret %d\n", i, ret);
+			return -1;
+		}
+		printf("set(%d, 0x%04x)\n", i, val);
+	}
+
+	// Delete all the even KVs.
+	for (int i = 0; i < 64; i += 2) {
+		ret = trait_del(traits, i);
+		if (ret < 0) {
+			printf("del(%d) ret %d\n", i, ret);
+			return -1;
+		}
+	}
+
+	// Read out all the odd KVs again.
+	for (int i = 1; i < 63; i += 2) {
+		ret = trait_get(traits, i, &got, sizeof(got));
+		if (ret < 0) {
+			printf("get(%d) ret %d\n", i, ret);
+			return -1;
+		}
+		want = (i << 9) | i << 1;
+		if (got != want) {
+			printf("get(%d) got 0x%04x want 0x%04x\n", i, got,
+			       want);
+			return -1;
+		}
+		printf("get(%d) 0x%04x\n", i, got);
+	}
+}

--- a/userspace-traits/x86_return_thunk.S
+++ b/userspace-traits/x86_return_thunk.S
@@ -1,0 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+.global __x86_return_thunk
+__x86_return_thunk:
+	ret


### PR DESCRIPTION
Changes since 002 (https://github.com/arthurfabre/linux/pull/1):

- Fix all `checkpatch.pl` warnings (except adding new files to MAINTAINERS).
- Fix bug where overwriting an existing key would still allocate memory for it.
- Dropped `SKBFL_HAS_TRAITS`: working on a better approach, storing the offset so we can use the `xdp_frame` space in `pskb_expand_head()`.
- Optimization attempt: force inline all helpers.
- Optimization attempt: inline memcpy() call to copy values to and from traits.
- Not for upstream: Userspace test (and future benchmark).